### PR TITLE
Revert to net 6

### DIFF
--- a/CsuChhs.Extensions.Tests/CsuChhs.Extensions.Tests.csproj
+++ b/CsuChhs.Extensions.Tests/CsuChhs.Extensions.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 	  <Nullable>enable</Nullable>
 	  <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>

--- a/CsuChhs.Extensions/CsuChhs.Extensions.csproj
+++ b/CsuChhs.Extensions/CsuChhs.Extensions.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 	  <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>CHHS Application Development Team</Authors>
-    <Version>1.5.0</Version>
+    <Version>1.5.1</Version>
     <PackageProjectUrl>https://github.com/csu-chhs/CsuChhs.Extensions</PackageProjectUrl>
     <Company>College of Health and Human Sciences</Company>
     <PackageId>CsuChhs.Extensions</PackageId>

--- a/CsuChhs.Extensions/NumberExtensions.cs
+++ b/CsuChhs.Extensions/NumberExtensions.cs
@@ -18,9 +18,9 @@
                 {
                     return TruncateDecimals((double)num, roundTo);
                 }
-                catch (ArgumentOutOfRangeException ex)
+                catch (ArgumentOutOfRangeException)
                 {
-                    throw ex;
+                    throw;
                 }
             }
 
@@ -81,9 +81,9 @@
             {
                 return (int)num.ToPercent(total);
             } 
-            catch (DivideByZeroException ex)
+            catch (DivideByZeroException)
             {
-                throw ex;
+                throw;
             }
         }
 

--- a/CsuChhs.Extensions/StringExtensions.cs
+++ b/CsuChhs.Extensions/StringExtensions.cs
@@ -169,7 +169,7 @@ namespace CsuChhs.Extensions
         /// </summary>
         /// <param name="value"></param>
         /// <returns>string</returns>
-        public static string ToCsvString(this string value)
+        public static string ToCsvString(this string? value)
         {
             if (!string.IsNullOrEmpty(value))
             {
@@ -178,7 +178,7 @@ namespace CsuChhs.Extensions
                     .Replace("\"", "")
                     .Replace(System.Environment.NewLine, " ");
             }
-            return value;
+            return string.Empty;
         }
 
         /// <summary>


### PR DESCRIPTION
We did not need to bump the .net version, reverting to 6.

Allow null values in ToCsvString()